### PR TITLE
Add and implement affectedBranches configuration in FileNameHook.

### DIFF
--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileNameHookSetting.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileNameHookSetting.java
@@ -9,10 +9,13 @@ public class FileNameHookSetting {
 
     private Pattern includePattern;
     private Optional<Pattern> excludePattern;
+    private Optional<Pattern> affectedBranches;
 
-    public FileNameHookSetting(String includePattern, String excludePattern) {
+    public FileNameHookSetting(String includePattern, String excludePattern, String affectedBranches) {
         this.includePattern = Pattern.compile(includePattern);
         this.excludePattern = Strings.isNullOrEmpty(excludePattern) ? Optional.empty() : Optional.of(Pattern.compile(excludePattern));
+        this.affectedBranches = Strings.isNullOrEmpty(affectedBranches) ?
+                Optional.empty() : Optional.of(Pattern.compile(affectedBranches));
     }
 
     public Pattern getIncludePattern() {
@@ -22,4 +25,6 @@ public class FileNameHookSetting {
     public Optional<Pattern> getExcludePattern() {
         return excludePattern;
     }
+
+    public Optional<Pattern> getAffectedBranches() { return affectedBranches; }
 }

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/Predicates.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/Predicates.java
@@ -4,7 +4,11 @@ import com.atlassian.bitbucket.content.Change;
 import com.atlassian.bitbucket.content.ChangeType;
 import com.atlassian.bitbucket.repository.RefChange;
 import com.atlassian.bitbucket.repository.RefChangeType;
+import com.atlassian.bitbucket.scm.git.GitRefPattern;
 import com.google.common.base.Predicate;
+
+import javax.annotation.Nullable;
+import java.util.regex.Pattern;
 
 public class Predicates {
 
@@ -42,4 +46,18 @@ public class Predicates {
             return !change.getType().equals(ChangeType.DELETE);
         }
     };
+
+    /**
+     * Predicate to check if the RefChange is in the @param affectedBranches
+     */
+    public static final Predicate<RefChange> filterBranchesPredicate(final Pattern affectedBranches) {
+        return new Predicate<RefChange>() {
+            @Override
+            public boolean apply(@Nullable RefChange refChange) {
+                String branchName = refChange.getRef().getId();
+                String unqualifiedBranchName = GitRefPattern.HEADS.unqualify(branchName);
+                return affectedBranches.matcher(unqualifiedBranchName).matches();
+            }
+        };
+    }
 }

--- a/src/main/resources/org/christiangalsterer/stash-filehooks-plugin.properties
+++ b/src/main/resources/org/christiangalsterer/stash-filehooks-plugin.properties
@@ -13,3 +13,4 @@ filename-hook.description=Reject commits that contain files matching a regular e
 filename-hook.includePattern.description=Pattern for the path and file name (e.g. \'.*\' for all files) to be included in the check.
 filename-hook.excludePattern.description=Pattern for the path and file name (e.g. \'.*\' for all files) to be excluded in the check.
 filename-hook.error.pattern=Pattern is not a valid regular expression
+filename-hook.affectedBranches.description=Pattern for branches which will be affected by the restriction. If left blank all branches are affected.

--- a/src/main/resources/static/filename.soy
+++ b/src/main/resources/static/filename.soy
@@ -18,15 +18,26 @@
     {/call}
 
     {call aui.form.textField}
-            {param id: 'pattern-exclude' /}
-            {param value: $config['pattern-exclude'] /}
-            {param isRequired: false /}
-            {param labelContent: 'Exclude Pattern' /}
-            {param descriptionText}
-                {getText('filename-hook.excludePattern.description')}
-            {/param}
-            {param errorTexts: $errors ? $errors['pattern-exclude'] : null /}
-        {/call}
+        {param id: 'pattern-exclude' /}
+        {param value: $config['pattern-exclude'] /}
+        {param isRequired: false /}
+        {param labelContent: 'Exclude Pattern' /}
+        {param descriptionText}
+            {getText('filename-hook.excludePattern.description')}
+        {/param}
+        {param errorTexts: $errors ? $errors['pattern-exclude'] : null /}
+    {/call}
+
+    {call aui.form.textField}
+        {param id: 'affected-branches' /}
+        {param value: $config['affected-branches'] /}
+        {param isRequired: false /}
+        {param labelContent: 'Affected branches' /}
+        {param descriptionText}
+            {getText('filename-hook.affectedBranches.description')}
+        {/param}
+        {param errorTexts: $errors ? $errors['affected-branches'] : null /}
+    {/call}
 {/template}
 
 


### PR DESCRIPTION
Add functionality which allows file name hook to be applied only on specific branches. Branches are configured with regex pattern.
