### PR TITLE
Return an empty set if changesets is empty

### DIFF
--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/ChangesetServiceImpl.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/ChangesetServiceImpl.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import static com.google.common.collect.Iterables.transform;
 
@@ -31,6 +32,10 @@ public class ChangesetServiceImpl implements ChangesetService {
             public Iterable<Change> apply(RefChange refChange) {
                 // TODO Ideally this is one diff-tree git call
                 Iterable<String> csetss = transform(getCommitsBetween(repository, refChange), Functions.COMMIT_TO_ID);
+                if (Iterables.size(csetss) == 0) {
+                    // Changesets empty so return an empty set
+                    return Collections.emptySet();
+                }
                 return Iterables.concat(Iterables.transform(getChangesets(repository, csetss), Functions.CHANGESET_TO_CHANGES));
             }
         });


### PR DESCRIPTION
Fixes #14 by checking if changesets is empty before trying to use CommitService.
