### PR TITLE
Performance and reliability fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The following example rejects all files matching the pattern **readme.md** when 
 
 ```
    Copyright 2015 Christian Galsterer
+   Copyright (C) 2017 Motorola Solutions, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <packaging>atlassian-plugin</packaging>
 
     <properties>
-        <bitbucket.version>5.2.0</bitbucket.version>
+        <bitbucket.version>4.8.0</bitbucket.version>
         <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
         <amps.version>6.3.0</amps.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,9 @@
     <packaging>atlassian-plugin</packaging>
 
     <properties>
-        <bitbucket.version>4.8.0</bitbucket.version>
+        <bitbucket.4x.version>4.8.0</bitbucket.4x.version>
+        <bitbucket.5x.version>5.4.1</bitbucket.5x.version>
+        <bitbucket.version>${bitbucket.4x.version}</bitbucket.version>
         <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
         <amps.version>6.3.0</amps.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
@@ -129,6 +131,18 @@
                             <instanceId>bitbucket</instanceId>
                             <version>${bitbucket.version}</version>
                             <dataVersion>${bitbucket.data.version}</dataVersion>
+                        </product>
+                        <product>
+                            <id>bitbucket</id>
+                            <instanceId>bitbucket-4x</instanceId>
+                            <version>${bitbucket.4x.version}</version>
+                            <dataVersion>${bitbucket.4x.version}</dataVersion>
+                        </product>
+                        <product>
+                            <id>bitbucket</id>
+                            <instanceId>bitbucket-5x</instanceId>
+                            <version>${bitbucket.5x.version}</version>
+                            <dataVersion>${bitbucket.5x.version}</dataVersion>
                         </product>
                     </products>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,23 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.christiangalsterer</groupId>
     <artifactId>stash-filehooks-plugin</artifactId>
-    <version>3.2.0</version>
+    <version>3.3.0-SNAPSHOT</version>
     <organization>
         <name>Christian Galsterer</name>
         <url>https://github.com/christiangalsterer/stash-filehooks-plugin</url>
     </organization>
+    <contributors>
+        <contributor>
+            <name>Krzysztof Malinowski</name>
+            <organization>Motorola Solutions, Inc.</organization>
+        </contributor>
+    </contributors>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
     <name>File Hooks Plugin</name>
     <description>Various hooks to check file attributes, like size, name.</description>
     <packaging>atlassian-plugin</packaging>

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/CachingResolver.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/CachingResolver.java
@@ -1,0 +1,89 @@
+package org.christiangalsterer.stash.filehooks.plugin.hook;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Implements an in-memory cache for values that are expensive to get (like external process calls).
+ *
+ * The cache is backed with a map of consumer defined types. CachingResolver will resolve values based on
+ * requested keys and get values either from cache or by invoking resolve function (and caching results).
+ * Actual way to get values is to be provided by consumer of the class upon resolving. Only missing entries
+ * (i.e. those not already cached) will be resolved using provided function.
+ *
+ * @param <K> type of keys to construct cache by
+ * @param <V> type of value elements to be stored in cache
+ */
+public class CachingResolver<K, V> {
+    private Map<K, V> cache = new HashMap<>();
+
+    /**
+     * Resolves requested key to a previously cached value.
+     *
+     * @param key requested key
+     * @return value if already cached or null if there is no cached value for the key
+     */
+    public V resolve(K key) {
+        return cache.get(key);
+    }
+
+    /**
+     * Resolves requested key using provided resolveFunction to get values not present in the cache.
+     *
+     * Value resolved by the resolveFunction will be stored in cache for future use.
+     *
+     * @param key requested key
+     * @param resolveFunction function to resolve key to value when the key is not in the cache
+     * @return resolved value
+     */
+    public V resolve(K key, Function<K, V> resolveFunction) {
+        return cache.computeIfAbsent(key, resolveFunction);
+    }
+
+    /**
+     * Resolves requested keys using provided resolveFunction to get values not present in the cache.
+     *
+     * resolveFunction will be called once for every key not yet present in cache. Resolved values
+     * will be stored in cache for future use.
+     *
+     * @param keys an iterable of keys to resolve
+     * @param resolveFunction function to resolve single key to a value when the key is not in cache
+     * @return a map representing requested keys and their corresponding values
+     */
+    public Map<K, V> resolve(Iterable<K> keys, Function<K, V> resolveFunction) {
+        Map<K, V> result = new HashMap<>();
+        for (K key : keys) {
+            result.put(key, resolve(key, resolveFunction));
+        }
+        return result;
+    }
+
+    /**
+     * Resolves requested keys using provided resolveFunction to get values not present in cache.
+     *
+     * resolveFunction will be called once for keys that are missing from the cache. This allows to get
+     * all missing values in one call, as this may be more efficient than getting missing values one by one.
+     * Resolved values will be stored in cache for future use.
+     *
+     * @param keys an iterable of keys to resolve
+     * @param resolveFunction function to resolve all keys missing from cache to corresponding values
+     * @return a map representing requested keys and their corresponding values
+     */
+    public Map<K, V> batchResolve(Iterable<K> keys,
+                                  Function<Iterable<K>, Map<K, V>> resolveFunction) {
+        Set<K> keysToResolve = StreamSupport.stream(keys.spliterator(), false)
+                .filter(key -> !cache.containsKey(key))
+                .collect(Collectors.toSet());
+
+        if (!keysToResolve.isEmpty()) {
+            cache.putAll(resolveFunction.apply(keysToResolve));
+        }
+
+        return StreamSupport.stream(keys.spliterator(), false)
+                .collect(Collectors.toMap(key -> key, key -> cache.get(key)));
+    }
+}

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/CatFileBatchCheckHandler.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/CatFileBatchCheckHandler.java
@@ -1,24 +1,22 @@
 package org.christiangalsterer.stash.filehooks.plugin.hook;
 
-import com.atlassian.fugue.Pair;
 import com.atlassian.bitbucket.io.LineReader;
 import com.atlassian.bitbucket.io.LineReaderOutputHandler;
 import com.atlassian.bitbucket.scm.CommandInputHandler;
 import com.atlassian.bitbucket.scm.CommandOutputHandler;
 import com.atlassian.utils.process.IOUtils;
 import com.atlassian.utils.process.ProcessException;
-import com.google.common.collect.Lists;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
-public class CatFileBatchCheckHandler extends LineReaderOutputHandler implements CommandInputHandler, CommandOutputHandler<List<Pair<String, Long>>> {
+public class CatFileBatchCheckHandler extends LineReaderOutputHandler implements CommandInputHandler, CommandOutputHandler<Map<String, Long>> {
 
 	private final Iterable<String> changesets;
-	private final List<Pair<String, Long>> values = Lists.newArrayList();
+    private final Map<String, Long> values = new HashMap<>();
 
 	CatFileBatchCheckHandler(Iterable<String> changesets) {
 		super(StandardCharsets.UTF_8);
@@ -26,7 +24,7 @@ public class CatFileBatchCheckHandler extends LineReaderOutputHandler implements
 	}
 
 	@Override
-	public List<Pair<String, Long>> getOutput() {
+	public Map<String, Long> getOutput() {
 		return values;
 	}
 
@@ -46,7 +44,7 @@ public class CatFileBatchCheckHandler extends LineReaderOutputHandler implements
 			String[] split = line.split(" ");
 			// Only process blobs (ie files), ignore folders
 			if (split.length == 3 && split[1].equals("blob")) {
-				values.add(Pair.pair(split[0], Long.parseLong(split[2])));
+				values.put(split[0], Long.parseLong(split[2]));
 			}
 		}
 	}

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/ChangesetService.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/ChangesetService.java
@@ -1,10 +1,12 @@
 package org.christiangalsterer.stash.filehooks.plugin.hook;
 
+import com.atlassian.bitbucket.commit.Commit;
 import com.atlassian.bitbucket.content.Change;
 import com.atlassian.bitbucket.repository.RefChange;
 import com.atlassian.bitbucket.repository.Repository;
 
 public interface ChangesetService {
-
     Iterable<Change> getChanges(Iterable<RefChange> refChanges, final Repository repository);
+    Iterable<Change> getChanges(final Repository repository, Iterable<Commit> commits);
+    Iterable<Commit> getCommitsBetween(final Repository repository, final RefChange refChange);
 }

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/ChangesetService.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/ChangesetService.java
@@ -5,8 +5,10 @@ import com.atlassian.bitbucket.content.Change;
 import com.atlassian.bitbucket.repository.RefChange;
 import com.atlassian.bitbucket.repository.Repository;
 
+import java.util.Map;
+
 public interface ChangesetService {
     Iterable<Change> getChanges(Iterable<RefChange> refChanges, final Repository repository);
-    Iterable<Change> getChanges(final Repository repository, Iterable<Commit> commits);
+    Map<Commit, Iterable<Change>> getChanges(final Repository repository, Iterable<Commit> commits);
     Iterable<Commit> getCommitsBetween(final Repository repository, final RefChange refChange);
 }

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/ChangesetService.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/ChangesetService.java
@@ -6,9 +6,10 @@ import com.atlassian.bitbucket.repository.RefChange;
 import com.atlassian.bitbucket.repository.Repository;
 
 import java.util.Map;
+import java.util.Set;
 
 public interface ChangesetService {
     Iterable<Change> getChanges(Iterable<RefChange> refChanges, final Repository repository);
     Map<Commit, Iterable<Change>> getChanges(final Repository repository, Iterable<Commit> commits);
-    Iterable<Commit> getCommitsBetween(final Repository repository, final RefChange refChange);
+    Set<Commit> getCommitsBetween(final Repository repository, Iterable<RefChange> refChanges);
 }

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/ChangesetServiceImpl.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/ChangesetServiceImpl.java
@@ -10,10 +10,7 @@ import com.google.common.collect.Iterables;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -34,25 +31,24 @@ public class ChangesetServiceImpl implements ChangesetService {
 
         for (RefChange refChange : refChanges) {
             Iterable<Commit> commits = getCommitsBetween(repository, refChange);
-            Iterables.addAll(changes, getChanges(repository, commits));
+            for (Iterable<Change> values : getChanges(repository, commits).values()) {
+                Iterables.addAll(changes, values);
+            }
         }
 
         return changes;
     }
 
     @Override
-    public Iterable<Change> getChanges(final Repository repository, Iterable<Commit> commits) {
-        List<Change> changes = new ArrayList<>();
+    public Map<Commit, Iterable<Change>> getChanges(final Repository repository, Iterable<Commit> commits) {
+        Map<Commit, Iterable<Change>> changesByCommit = new HashMap<>();
 
         Iterable<Changeset> changesets = getChangesets(repository, commits);
         for (Changeset changeset : changesets) {
-            Iterable<Change> values = changeset.getChanges().getValues();
-            for (Change change : values) {
-                changes.add(change);
-            }
+            changesByCommit.put(changeset.getToCommit(), changeset.getChanges().getValues());
         }
 
-        return changes;
+        return changesByCommit;
     }
 
     @Override

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/ChangesetServiceImpl.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/ChangesetServiceImpl.java
@@ -4,13 +4,12 @@ import com.atlassian.bitbucket.commit.*;
 import com.atlassian.bitbucket.content.Change;
 import com.atlassian.bitbucket.repository.RefChange;
 import com.atlassian.bitbucket.repository.Repository;
-import com.atlassian.bitbucket.util.*;
-import com.google.common.collect.ImmutableSet;
+import com.atlassian.bitbucket.util.PageRequestImpl;
+import com.atlassian.bitbucket.util.PagedIterable;
 import com.google.common.collect.Iterables;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -31,29 +30,35 @@ public class ChangesetServiceImpl implements ChangesetService {
         List<Change> changes = new ArrayList<>();
 
         for (RefChange refChange : refChanges) {
-            Iterable<String> commitIds = StreamSupport.stream(getCommitsBetween(repository, refChange).spliterator(),false).map(Functions.COMMIT_TO_COMMIT_ID).collect(Collectors.toList());
-            if (Iterables.size(commitIds) == 0) {
-                return Collections.emptySet();
-            }
+            Iterable<Commit> commits = getCommitsBetween(repository, refChange);
+            Iterables.addAll(changes, getChanges(repository, commits));
+        }
 
-            Iterable<Changeset> changesets = getChangesets(repository, commitIds);
-            for (Changeset changeset : changesets) {
-                Iterable<Change> values = changeset.getChanges().getValues();
-                for (Change change : values) {
-                    changes.add(change);
-                }
+        return changes;
+    }
+
+    @Override
+    public Iterable<Change> getChanges(final Repository repository, Iterable<Commit> commits) {
+        List<Change> changes = new ArrayList<>();
+
+        Iterable<Changeset> changesets = getChangesets(repository, commits);
+        for (Changeset changeset : changesets) {
+            Iterable<Change> values = changeset.getChanges().getValues();
+            for (Change change : values) {
+                changes.add(change);
             }
         }
 
         return changes;
     }
 
-    private Iterable<Commit> getCommitsBetween(final Repository repository, final RefChange refChange) {
+    @Override
+    public Iterable<Commit> getCommitsBetween(final Repository repository, final RefChange refChange) {
         return new PagedIterable<>(pageRequest -> {
             if (refChange.getFromHash().equals("0000000000000000000000000000000000000000")) {
                 return commitService.getCommitsBetween(new CommitsBetweenRequest.Builder(repository)
-                                                       .include(refChange.getToHash())
-                                                       .build(), pageRequest);
+                        .include(refChange.getToHash())
+                        .build(), pageRequest);
             }
             return commitService.getCommitsBetween(new CommitsBetweenRequest.Builder(repository)
                     .exclude(refChange.getFromHash())
@@ -62,10 +67,12 @@ public class ChangesetServiceImpl implements ChangesetService {
         }, PAGE_REQUEST);
     }
 
-    private Iterable<Changeset> getChangesets(final Repository repository, Iterable<String> commitIds) {
-        final Collection<String> cids = ImmutableSet.copyOf(commitIds);
+    private Iterable<Changeset> getChangesets(final Repository repository, Iterable<Commit> commits) {
+        final Collection<String> commitIds = StreamSupport.stream(commits.spliterator(), false)
+                .map(Commit::getId)
+                .collect(Collectors.toSet());
         return new PagedIterable<>(pageRequest -> commitService.getChangesets(new ChangesetsRequest.Builder(repository)
-                .commitIds(cids)
+                .commitIds(commitIds)
                 .maxChangesPerCommit(MAX_CHANGES_PER_COMMIT)
                 .build(), pageRequest), PAGE_REQUEST);
     }

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileSizeHook.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileSizeHook.java
@@ -119,9 +119,9 @@ public class FileSizeHook implements PreReceiveRepositoryHook {
                     .filter(isNotDeleteChange)
                     .filter(change -> {
                         String fullPath = change.getPath().toString();
-                        return includePattern.matcher(fullPath).matches()
+                        return includePattern.matcher(fullPath).find()
                                 && (!setting.getExcludePattern().isPresent()
-                                || !setting.getExcludePattern().get().matcher(fullPath).matches());
+                                || !setting.getExcludePattern().get().matcher(fullPath).find());
                     })
                     .collect(Collectors.toList());
 

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileSizeHook.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileSizeHook.java
@@ -12,6 +12,7 @@ import com.atlassian.bitbucket.scm.PluginCommandBuilderFactory;
 import com.atlassian.bitbucket.scm.git.command.GitCommandBuilderFactory;
 import com.atlassian.bitbucket.setting.Settings;
 import com.atlassian.fugue.Pair;
+import com.google.common.collect.Iterables;
 
 import javax.annotation.Nonnull;
 import java.time.Duration;
@@ -87,6 +88,12 @@ public class FileSizeHook implements PreReceiveRepositoryHook {
                                             hookResponse.out().format("Getting commits: %d ms\n",
                                                     Duration.between(start, Instant.now()).toMillis());
                                             Iterable<Commit> refCommits = changesetService.getCommitsBetween(repository, x);
+                                            hookResponse.out().format("Got commits: %d ms\n",
+                                                    Duration.between(start, Instant.now()).toMillis());
+                                            hookResponse.out().format("Got commits, size %d: %d ms\n",
+                                                    Iterables.size(refCommits), Duration.between(start, Instant.now()).toMillis());
+                                            hookResponse.out().format("Got commits, size %d: %d ms\n",
+                                                    Iterables.size(refCommits), Duration.between(start, Instant.now()).toMillis());
                                             hookResponse.out().format("Got commits: %d ms\n",
                                                     Duration.between(start, Instant.now()).toMillis());
                                             return refCommits;

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileSizeHook.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileSizeHook.java
@@ -12,7 +12,6 @@ import com.atlassian.bitbucket.scm.PluginCommandBuilderFactory;
 import com.atlassian.bitbucket.scm.git.command.GitCommandBuilderFactory;
 import com.atlassian.bitbucket.setting.Settings;
 import com.atlassian.fugue.Pair;
-import com.google.common.collect.Iterables;
 
 import javax.annotation.Nonnull;
 import java.time.Duration;
@@ -88,12 +87,6 @@ public class FileSizeHook implements PreReceiveRepositoryHook {
                                             hookResponse.out().format("Getting commits: %d ms\n",
                                                     Duration.between(start, Instant.now()).toMillis());
                                             Iterable<Commit> refCommits = changesetService.getCommitsBetween(repository, x);
-                                            hookResponse.out().format("Got commits: %d ms\n",
-                                                    Duration.between(start, Instant.now()).toMillis());
-                                            hookResponse.out().format("Got commits, size %d: %d ms\n",
-                                                    Iterables.size(refCommits), Duration.between(start, Instant.now()).toMillis());
-                                            hookResponse.out().format("Got commits, size %d: %d ms\n",
-                                                    Iterables.size(refCommits), Duration.between(start, Instant.now()).toMillis());
                                             hookResponse.out().format("Got commits: %d ms\n",
                                                     Duration.between(start, Instant.now()).toMillis());
                                             return refCommits;

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileSizeHook.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileSizeHook.java
@@ -19,7 +19,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.Iterables.addAll;
-import static org.christiangalsterer.stash.filehooks.plugin.hook.Predicates.*;
+import static org.christiangalsterer.stash.filehooks.plugin.hook.Predicates.isNotDeleteChange;
+import static org.christiangalsterer.stash.filehooks.plugin.hook.Predicates.matchesBranchPattern;
 
 /**
  * Checks the size of a file in the pre-receive phase and rejects the push when the changeset contains files which exceed the configured file size limit.
@@ -56,8 +57,7 @@ public class FileSizeHook implements PreReceiveRepositoryHook {
             Long maxFileSize = setting.getSize();
             Optional<Pattern> branchesPattern = setting.getBranchesPattern();
 
-            Stream<RefChange> filteredRefChanges = refChanges.stream()
-                    .filter(isNotTagRefChange);
+            Stream<RefChange> filteredRefChanges = refChanges.stream();
 
             if (branchesPattern.isPresent()) {
                 filteredRefChanges = filteredRefChanges

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileSizeHookValidator.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileSizeHookValidator.java
@@ -2,11 +2,9 @@ package org.christiangalsterer.stash.filehooks.plugin.hook;
 
 import com.atlassian.bitbucket.i18n.I18nService;
 import com.atlassian.bitbucket.repository.Repository;
-import com.atlassian.bitbucket.scope.Scope;
 import com.atlassian.bitbucket.setting.RepositorySettingsValidator;
 import com.atlassian.bitbucket.setting.Settings;
 import com.atlassian.bitbucket.setting.SettingsValidationErrors;
-import com.atlassian.bitbucket.setting.SettingsValidator;
 import com.google.common.base.Strings;
 
 import javax.annotation.Nonnull;
@@ -14,7 +12,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-public class FileSizeHookValidator implements SettingsValidator {
+public class FileSizeHookValidator implements RepositorySettingsValidator {
 
     private static final int MAX_SETTINGS = 5;
     private static final String SETTINGS_INCLUDE_PATTERN_PREFIX = "pattern-";
@@ -29,7 +27,7 @@ public class FileSizeHookValidator implements SettingsValidator {
     }
 
     @Override
-    public void validate(@Nonnull Settings settings, @Nonnull SettingsValidationErrors errors, @Nonnull Scope scope) {
+    public void validate(@Nonnull Settings settings, @Nonnull SettingsValidationErrors errors, @Nonnull Repository repository) {
 
         int patternParams = 0;
 

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FlatteningCachingResolver.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FlatteningCachingResolver.java
@@ -1,0 +1,48 @@
+package org.christiangalsterer.stash.filehooks.plugin.hook;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * A {@link CachingResolver} designed for values that are iterables.
+ *
+ * @param <K> type of keys to construct cache by
+ * @param <V> type of values that will be held as {@link Iterable}s
+ */
+public class FlatteningCachingResolver<K, V> extends CachingResolver<K, Iterable<V>> {
+    /**
+     * Resolved selected keys to values, then flattens the results to create single set of values.
+     *
+     * Value resolution is done with {@link CachingResolver#resolve(Iterable, Function)}.
+     *
+     * @param keys an iterable of keys to resolve
+     * @param resolveFunction function to resolve single key to a value when the key is not in cache
+     * @return a set of values resolved for all requested keys
+     */
+    public Set<V> flatResolve(Iterable<K> keys, Function<K, Iterable<V>> resolveFunction) {
+        return flatten(resolve(keys, resolveFunction));
+    }
+
+    /**
+     * Resolved selected keys to values, then flattens the results to create single set of values.
+     *
+     * Value resolution is done with {@link CachingResolver#batchResolve(Iterable, Function)}.
+     *
+     * @param keys an iterable of keys to resolve
+     * @param resolveFunction function to resolve single key to a value when the key is not in cache
+     * @return a set of values resolved for all requested keys
+     */
+    public Set<V> flatBatchResolve(Iterable<K> keys,
+                                   Function<Iterable<K>, Map<K, Iterable<V>>> resolveFunction) {
+        return flatten(batchResolve(keys, resolveFunction));
+    }
+
+    private Set<V> flatten(Map<?, Iterable<V>> source) {
+        return source.values().stream()
+                .flatMap(x -> StreamSupport.stream(x.spliterator(), false))
+                .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
As a follow-up for #1, I would like to submit my changes. These were mostly around performance, but also two bugfixes:
- only 100 files per commit were checked,
- pattern matching behavior changed in 3.1.0.

Since my use case was to prevent large files uploaded (that should go into LFS), the first limitation was a major drawback that allowed large files to slip through.

As for performance, I have tested scenarios with file size hook with two different patterns set:
- pushing 3 branches (2244, 1470 and 2130 new commits respectively) with some commits changing over 2000 files - hook time inspection: 4.5 seconds (reduced from 55 seconds),
- pushing whole repository (2868 branches, 1.8 GiB in total) - hook time inspection: 89 seconds (previously hook was killed by Bitbucket after 3 hours of running).

Every commit that introduced a performance change is accompanied with a longer description why the change was made and what was the result.

Please feel free to review and accept unless there are concerns. Should you have any questions, please don't hesitate to ask.