### PR TITLE
Fix NPEs when pre-populating size cache

### DIFF
--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileSizeHook.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileSizeHook.java
@@ -143,6 +143,13 @@ public class FileSizeHook implements PreReceiveRepositoryHook {
                 .argument("--batch-check")
                 .inputHandler(handler)
                 .build(handler);
-        return cmd.call();
+        return filterOutNullSizes(cmd.call());
+    }
+
+    private Map<String, Long> filterOutNullSizes(Map<String, Long> sizes) {
+        return sizes.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue() != null)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 }


### PR DESCRIPTION
Filter out null size values when calculating the sizes
of the objects in a commit.