### PR TITLE
fix NPE for git submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ The following example rejects all files matching the pattern **readme.md** when 
 
 ![File Size Hook Configuration](screenshots/file-hooks-plugin-filename-hook-configuration.png)
 
+## Debugging
+
+```
+mvn bitbucket:run
+curl -u admin -v -X PUT -d "" -H "Content-Type: application/json" http://localhost:7990/bitbucket/rest/api/latest/logs/rootLogger/debug
+
+```
+
 # Releases
 
 3.3.2 (2018-04-15)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.christiangalsterer</groupId>
     <artifactId>stash-filehooks-plugin</artifactId>
-    <version>3.3.2</version>
+    <version>3.3.3-SNAPSHOT</version>
     <organization>
         <name>Christian Galsterer</name>
         <url>https://github.com/christiangalsterer/stash-filehooks-plugin</url>

--- a/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileSizeHook.java
+++ b/src/main/java/org/christiangalsterer/stash/filehooks/plugin/hook/FileSizeHook.java
@@ -84,7 +84,7 @@ public class FileSizeHook implements PreReceiveRepositoryHook {
                     contentIds -> getSizeForContentIds(repository, contentIds));
 
             List<String> filteredPaths = filteredChanges.stream()
-                    .filter(change -> sizesByContentId.resolve(change.getContentId()) > maxFileSize)
+                    .filter(change -> sizesByContentId.resolve(change.getContentId(), 0L) > maxFileSize)
                     .map(change -> change.getPath().toString())
                     .collect(Collectors.toList());
 


### PR DESCRIPTION
fixes #29 support git submodules
After the fix
```
git submodule status
 dbe01bd8e182044e83bfe052dc98d1f59e452ffb utilities (heads/master)
 
git push 

2019-05-05 12:11:36,470 DEBUG [threadpool:thread-2] admin @42NCYSx731x15x0 127.0.0.1 "POST /scm/project_1/rep_1.git/git-receive-pack HTTP/1.1" o.c.s.f.plugin.hook.CachingResolver key dbe01bd8e182044e83bfe052dc98d1f59e452ffb not found, use default value 0
```